### PR TITLE
Changed output encoding to UTF8

### DIFF
--- a/ClrHttpRequest/clr_http_request.cs
+++ b/ClrHttpRequest/clr_http_request.cs
@@ -157,7 +157,7 @@ public partial class UserDefinedFunctions
             if (requestMethod.ToUpper() != "GET" && !string.IsNullOrWhiteSpace(parameters))
             {
                 // Convert to byte array
-                var parameterData = Encoding.ASCII.GetBytes(parameters);
+                var parameterData = Encoding.UTF8.GetBytes(parameters);
 
                 // Set content info
                 if (!contentLengthSetFromHeaders)


### PR DESCRIPTION
Issues were detected when trying to send unicode-encoded payloads using the CLR method.
The result on the other end came out as question marks.

The root cause was found to be the ASCII encoding setting in the method, which should be replaced with UTF8.